### PR TITLE
add pom.xml for maven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 releases
 /bin/
+target

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,91 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>de.willuhn.jameica</groupId>
+  <artifactId>jameica-util</artifactId>
+  <version>2.6.7-SNAPSHOT</version>
+  <name>Jameica Utility classes</name>
+
+  <properties>
+    <encoding>ISO-8859-1</encoding>
+    <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>ISO-8859-1</project.reporting.outputEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <project.build.sourceDirectory>src/</project.build.sourceDirectory>
+  </properties>
+
+  <dependencies>
+  </dependencies>
+
+  <build>
+    <!-- weicht von der Konvention ab -->
+    <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+
+    <plugins>
+      <!-- reconfigure for source, target, encoding -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <encoding>${project.build.sourceEncoding}</encoding>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.source}</target>
+        </configuration>
+      </plugin>
+
+      <!-- attach sources during package phase -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- attach javadoc during package phase -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+
+  <!-- disable doclint in jdk8 -->
+  <profiles>
+    <profile>
+      <id>doclint-java8-disable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>


### PR DESCRIPTION
Mit dieser Datei lässt sich die Library mittels Maven bauen.

Vorteil: Es werden ein Binär-Archiv, Javadoc-Archiv und ein Sources-Archiv gebaut. Damit lässt sich das Projekt über verschiedene Dependency-Management-Tools (Maven selbst, Gradle, Ant+Ivy, Leningen, etc.) wesentlich leichter einbinden. In Eclipse, IntelliJ oder auch Netbeans erscheinen damit auch automatisch die Sourcen, eine IDE ist aber keine Vorraussetzung.

Dies sollte der erste Schritt zu einem Meta-Projekt sein: ein übergeordnetes Github-Projekt mit nur einer pom.xml, und git-submodules -- dazu später gerne mehr.

Die pom.xml ermöglicht auch eine Einbindung in automatische Test-Suiten, wie etwa travis-ci.org.

Letztendlich schadet diese Datei auch nicht -- es passiert ja nichts weiter automatisch. Damit ist dieser Pullrequest auch völlig ungefährilch.

Beispiel Build:

```
$ mvn clean package
[INFO] Building jar: target/jameica-util-2.6.7-SNAPSHOT.jar
[INFO] Building jar: target/jameica-util-2.6.7-SNAPSHOT-sources.jar
[INFO] Building jar: target/jameica-util-2.6.7-SNAPSHOT-javadoc.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS

$ ls -1 target/j*.jar
target/jameica-util-2.6.7-SNAPSHOT.jar
target/jameica-util-2.6.7-SNAPSHOT-javadoc.jar
target/jameica-util-2.6.7-SNAPSHOT-sources.jar
```
