### PR TITLE
JavaDoc läuft auf Fehler wegen spitzen Klammern

### DIFF
--- a/src/de/willuhn/util/Base64.java
+++ b/src/de/willuhn/util/Base64.java
@@ -19,7 +19,7 @@ import de.willuhn.logging.Logger;
 /**
  * Kleine Hilfe-Klasse zum Encoden und Decoden von Base64.
  * Der Zugriff auf die Encoder/Decoder von Java geschieht per Reflection, damit die Klasse sowohl
- * unter Java < 8 lauffaehig ist (dort existiert java.util.Base64 noch nicht) als auch unter Java >= 9
+ * unter Java &lt; 8 lauffaehig ist (dort existiert java.util.Base64 noch nicht) als auch unter Java &ge; 9
  * (dort existiert "sun.misc.BASE64*" nicht mehr).
  */
 public class Base64

--- a/src/de/willuhn/util/Settings.java
+++ b/src/de/willuhn/util/Settings.java
@@ -368,7 +368,7 @@ public class Settings
   }
 
 	/**
-   * Speichert das Attribut <name> mit dem zugehoerigen Wert <value>.
+   * Speichert das Attribut <tt>name</tt> mit dem zugehoerigen Wert <tt>value</tt>.
    * Wenn ein gleichnamiges Attribut bereits existiert, wird es ueberschrieben.
    * Ist der Wert des Attributes <code>null</code>, wird es entfernt.
    * @param name Name des Attributs.
@@ -396,7 +396,7 @@ public class Settings
   }
 
   /**
-   * Speichert das Attribut <name> mit der zugehoerigen Liste von Werten <value>.
+   * Speichert das Attribut <tt>name</tt> mit der zugehoerigen Liste von Werten <tt>value</tt>.
    * Wenn ein gleichnamiges Attribut bereits existiert, werden dessen Werte ueberschrieben.
    * Ist der Wert des Attributes <code>null</code>, wird es entfernt.
    * Von dem Array werden die ersten maximal 256 Elemente gespeichert.


### PR DESCRIPTION
Das Tool `javadoc` bricht den Erstellprozess mit einer Fehlermeldung ab. Grund
dafür sind die spitzen Klammern für "größer" bzw. "kleiner". Das Tool geht
davon aus, dass es sich um HTML-Tags handelt und erkennt sie dann nicht. Durch
Umschreiben in den jeweiligen HTML-Code wird in der IDE weiterhin das korrekte
Zeichen angezeigt und der Job erzeugt ebenfalls wieder korrekte HTML-Seiten.