### PR TITLE
Gradle #2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id 'java-library'
-    id 'eclipse'
-    id 'idea'
+    id 'my.java-library-conventions'
+    id 'my.java-oldschool-project-structure'
+    id 'my.encoding.8859-1'
 }
 
 group 'de.willuhn.jameica'
@@ -13,40 +13,6 @@ java {
     }
 }
 
-tasks.withType(JavaCompile) {
-    options.encoding = 'ISO-8859-1'
-}
-tasks.withType(Javadoc) {
-    options.encoding = 'ISO-8859-1'
-}
-
 jar {
     baseName "de_willuhn_${project.name}"
-}
-
-sourceSets {
-    main {
-        java {
-            srcDirs = ['src']
-        }
-    }
-
-    test {
-        java {
-            srcDirs = ['test']
-        }
-    }
-}
-
-eclipse {
-    classpath {
-        downloadJavadoc = true
-        downloadSources = false
-    }
-}
-idea {
-    module {
-        downloadJavadoc = true
-        downloadSources = false
-    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,9 @@ java {
     }
 }
 
+// solange noch die Logik des ANT-Builds benötigt wird, nutze einen Unterordner
+buildDir = file("./build/gradle/")
+
 jar {
     baseName "de_willuhn_${project.name}"
 }


### PR DESCRIPTION
Ich habe die redundanten Konfigurationen in zentrale Dateien verschoben, wodurch die `build.gradle` deutlich kürzer wird und sich nur auf die projektspezifischen Unterschiede konzentriert.