### PR TITLE
entferne `@author`

### DIFF
--- a/src/de/willuhn/boot/BootStrap.java
+++ b/src/de/willuhn/boot/BootStrap.java
@@ -31,7 +31,6 @@ import de.willuhn.logging.Logger;
  * [1]    Vollstaendiger Name der zu ladenden Klasse.
  * [2]    Basis-Verzeichnis, in dem rekursiv nach Jars und Klassen gesucht werden soll.
  * [3]... Liste von Parametern, die an die eigentlich Anwendung durchgereicht werden sollen.
- * @author willuhn
  */
 public class BootStrap
 {

--- a/src/de/willuhn/io/AbstractZipSupport.java
+++ b/src/de/willuhn/io/AbstractZipSupport.java
@@ -14,7 +14,6 @@ import de.willuhn.util.ProgressMonitor;
 
 /**
  * Abstrakte Basisklasse fuer ZIP-Support.
- * @author willuhn
  */
 public class AbstractZipSupport
 {

--- a/src/de/willuhn/io/FileWatch.java
+++ b/src/de/willuhn/io/FileWatch.java
@@ -19,7 +19,6 @@ import java.util.Vector;
 
 /**
  * Diese Klasse kann Dateien ueberwachen und bei Aenderung ein Event ausloesen.
- * @author willuhn
  */
 public class FileWatch
 {

--- a/src/de/willuhn/io/ZipExtractor.java
+++ b/src/de/willuhn/io/ZipExtractor.java
@@ -25,7 +25,6 @@ import de.willuhn.util.ProgressMonitor;
 
 /**
  * Hilfklasse zum Entpacken von ZIP-Archiven.
- * @author willuhn
  */
 public class ZipExtractor extends AbstractZipSupport
 {

--- a/src/de/willuhn/logging/Logger.java
+++ b/src/de/willuhn/logging/Logger.java
@@ -23,7 +23,6 @@ import de.willuhn.util.Queue.QueueFullException;
 
 /**
  * Kleiner System-Logger.
- * @author willuhn
  */
 public class Logger
 {

--- a/src/de/willuhn/logging/targets/LogrotateTarget.java
+++ b/src/de/willuhn/logging/targets/LogrotateTarget.java
@@ -31,7 +31,6 @@ import de.willuhn.logging.Message;
 /**
  * Implementierung eines Targets, welches nach einer definierten Dateigroesse
  * das Log-File rotiert und optional zippt.
- * @author willuhn
  */
 public class LogrotateTarget implements Target
 {

--- a/src/de/willuhn/util/ApplicationException.java
+++ b/src/de/willuhn/util/ApplicationException.java
@@ -20,7 +20,6 @@ package de.willuhn.util;
  * zeigt ihn in der Oberflaeche an.
  * Konsequenz: Fehlertexte in dieser Exception muessen fuer den
  * End-Benutzer! verstaendlich formuliert sein.
- * @author willuhn
  */
 public class ApplicationException extends Exception
 {

--- a/src/de/willuhn/util/I18N.java
+++ b/src/de/willuhn/util/I18N.java
@@ -27,7 +27,6 @@ import de.willuhn.logging.*;
  * Sie uebersetzt nicht nur alle Strings sondern speichert auch alle
  * nicht uebersetzbaren Strings waehrend der aktuellen Sitzung und
  * speichert diese beim Beenden der Anwendung im Temp-Verzeichnis ab.
- * @author willuhn
  */
 public class I18N
 {

--- a/src/de/willuhn/util/Session.java
+++ b/src/de/willuhn/util/Session.java
@@ -20,7 +20,6 @@ import de.willuhn.logging.Logger;
 
 /**
  * Implementierung eines Session-Containers.
- * @author willuhn
  */
 public class Session extends Observable
 {
@@ -215,7 +214,6 @@ public class Session extends Observable
   
   /**
    * Der Worker-Thread.
-   * @author willuhn
    */
   private final static class Worker extends Thread
   {

--- a/src/de/willuhn/util/Settings.java
+++ b/src/de/willuhn/util/Settings.java
@@ -38,7 +38,6 @@ import de.willuhn.logging.Logger;
  * sondern sie bereits mit Default-Werten in den Dateien vorfindet.
  * Wird die Properties-Datei von aussen (z.Bsp. mit einem Texteditor)
  * geaendert, wird das automatisch erkannt und die Datei intern neu geladen.
- * @author willuhn
  */
 public class Settings
 {


### PR DESCRIPTION
In einigen wenigen Dateien existiert ein `@author`-Eintrag.
Das ist in Zeiten von Git nicht mehr notwendig.

Siehe auch https://github.com/willuhn/hibiscus/pull/83