### PR TITLE
Level: class -> enum

### DIFF
--- a/src/de/willuhn/logging/JavaLoggingHandler.java
+++ b/src/de/willuhn/logging/JavaLoggingHandler.java
@@ -33,7 +33,7 @@ public class JavaLoggingHandler extends Handler
 {
   private final static Handler singleton = new JavaLoggingHandler();
   
-  private static Map logMapping = new HashMap();
+  private static Map<java.util.logging.Level, Level> logMapping = new HashMap();
   static
   {
     try
@@ -78,9 +78,9 @@ public class JavaLoggingHandler extends Handler
     if (record == null)
       return;
     
-    Level level = (Level) logMapping.get(record.getLevel());
+    Level level = logMapping.get(record.getLevel());
     if (level == null)
-      level = Level.DEFAULT;
+      level = Logger.DEFAULT;
         
     String message = record.getMessage();
     Throwable t    = record.getThrown();

--- a/src/de/willuhn/logging/Level.java
+++ b/src/de/willuhn/logging/Level.java
@@ -10,113 +10,43 @@
  **********************************************************************/
 package de.willuhn.logging;
 
-import java.util.Hashtable;
-
 /**
  * Log-Level.
  */
-public class Level
+public enum Level
 {
+  TRACE,
+  DEBUG,
+  INFO,
+  WARN,
+  ERROR;
 
-	private String name;
-	private int value;
-
-	private static Hashtable registry = new Hashtable();
-
-  /**
-   * Vordefinierter Log-Level fuer Trace-Meldungen.
-   * Sie liegen noch unterhalb von DEBUG.
-   */
-  public final static Level TRACE  = new Level("TRACE",0);
-
-	/**
-	 * Vordefinierter Log-Level fuer Debug-Meldungen.
-	 */
-	public final static Level DEBUG  = new Level("DEBUG",1);
-
-	/**
-	 * Vordefinierter Log-Level fuer regulaere Meldungen.
-	 */
-	public final static Level INFO   = new Level("INFO",100);
-
-	/**
-	 * Vordefinierter Log-Level fuer Warnungen.
-	 */
-	public final static Level WARN   = new Level("WARN",300);
-
-	/**
-	 * Vordefinierter Log-Level fuer Fehler.
-	 */
-	public final static Level ERROR  = new Level("ERROR",500);
-	
-	/**
-	 * Default-Loglevel.
-	 */
-	public final static Level DEFAULT = INFO;
-
-  /**
-   * ct.
-   * @param name Name des Levels (zb "DEBUG").
-   * @param value Wertigkeit des Levels.
-   * Level mit hoher Prioritaet (z.Bsp. "ERROR" oder "WARNING" haben
-   * eine hohe Wertigkeit, informative und Debug-Levels eine niedrige. 
-   */
-  public Level(String name, int value)
-  {
-  	this.name  = (name == null ? "" : name);
-  	this.value = value;
-
-		registry.put(name,this);
-  }
-
-	/**
-	 * Liefert die Wertigkeit des Levels.
-   * @return Wertigkeit.
-   */
-  public int getValue()
-	{
-		return value;
-	}
-	
-	/**
-	 * Liefert den Namen des Levels.
-   * @return Name des Levels.
-   */
-  public String getName()
-	{
-		return name;
-	}
-
-	/**
-	 * Findet ein Log-Level anhand seines Namens.
-   * @param name Name des Log-Levels, nach dem gesucht wird.
-   * @return der gefundene Log-Level oder <code>null</code>.
-   */
-  public static Level findByName(String name)
-	{
-		return (Level) registry.get(name);
-	}
-  /**
-   * @see java.lang.Object#equals(java.lang.Object)
-   */
-  public boolean equals(Object obj)
-  {
-  	return ((Level)obj).value == this.value;
-  }
-
-  /**
-   * @see java.lang.Object#toString()
-   */
+  @Override
   public String toString()
   {
-    return "Name: " + name + ", Level: " + value;
+    return "Name: " + this.name();
   }
 
+  /**
+   * Prüft, ob mit dem übergebenen Log-Level Meldungen geloggt werden sollen.
+   *
+   * @param l das zu testende Log-Level.
+   * @return {@code true}, wenn Log-Level eingeschaltet, sonst {@code false}.
+   */
+  public boolean includes(Level l)
+  {
+    return l != null && 0 <= this.compareTo(l);
+  }
 }
-
 
 /**********************************************************************
  * $Log: Level.java,v $
+ * Revision 1.6  2021/07/26 21:37:29  ruderphilipp
+ * Umwandlung von class in enum
+ *
+ * Revision 1.5  2013/09/21 23:18:43  willuhn
+ * @N Neues Log-Level "TRACE" unterhalb von "DEBUG"
+ *
  * Revision 1.4  2005/03/24 17:28:25  web0
  * @B bug in Level.findByName
  *

--- a/src/de/willuhn/logging/Logger.java
+++ b/src/de/willuhn/logging/Logger.java
@@ -38,7 +38,10 @@ public class Logger
   // wenn man irgendwo in der Anwendung mal die letzten Zeilen des Logs ansehen will.
   private static History lastLines = new History(BUFFER_SIZE);
 
-	private static Level level = Level.DEFAULT;
+	public static final Level DEFAULT = Level.INFO;
+
+	/** hält den aktuellen Wert vom Loglevel */
+	private static Level level = DEFAULT;
 
 	private static LoggerThread lt = null;
 	
@@ -103,7 +106,7 @@ public class Logger
    */
   public static boolean isLogging(Level l)
   {
-    return l != null && l.getValue() >= Logger.level.getValue();
+    return Logger.level.includes(l);
   }
 
   /**
@@ -256,7 +259,7 @@ public class Logger
   {
     // Wir checken, ob der uebergebene Level mindestens genauso wertig ist,
     // wie unser aktueller
-    if (level.getValue() < Logger.level.getValue())
+    if (!Logger.level.includes(level))
       return;
 
     if (t != null)

--- a/src/de/willuhn/logging/Message.java
+++ b/src/de/willuhn/logging/Message.java
@@ -132,7 +132,7 @@ public class Message
     if (this.level != null)
     {
       sb.append("[");
-      sb.append(this.level.getName());
+      sb.append(this.level.name());
       sb.append("]");
     }
 

--- a/src/de/willuhn/logging/targets/SyslogTarget.java
+++ b/src/de/willuhn/logging/targets/SyslogTarget.java
@@ -68,7 +68,7 @@ public class SyslogTarget implements Target
   {
   	if (message == null)
   		return;
-		String s = "[" + message.getLevel().getName() + "] " + message.getText();
+		String s = "[" + message.getLevel().name() + "] " + message.getText();
   	byte[] data = s.getBytes();
 
 		DatagramPacket packet = new DatagramPacket(data, data.length, targetHost, port);


### PR DESCRIPTION
Das Log-Level ist als _Klasse_ mit konstanten Integer-Werten implementiert. Für einen sauberen Code-Stil sollte hier ein Enum verwendet werden.

Somit wird der Implementierungscode deutlich kürzer und weniger fehleranfällig, während auf der nutzenden Seite fast nichts verändert werden muss.